### PR TITLE
[Feature] User deletion

### DIFF
--- a/api/test/controllers/user_controller_test.exs
+++ b/api/test/controllers/user_controller_test.exs
@@ -9,6 +9,11 @@ defmodule Mito.UserControllerTest do
 
   setup %{conn: conn} do
     {:ok, conn: put_req_header(conn, "accept", "application/json")}
+
+    case :ejabberd_auth.user_exists(@valid_attrs.username, "localhost") do
+      true  -> :ejabberd_auth.remove_user(@valid_attrs.username, "localhost")
+      _ -> :ok
+    end
   end
 
   test "lists all entries on index", %{conn: conn} do
@@ -16,7 +21,7 @@ defmodule Mito.UserControllerTest do
     assert json_response(conn, 200)["data"] == []
   end
 
-  test "shows chosen resource", %{conn: conn} do
+  test "shows chosen user", %{conn: conn} do
     user = insert(:user)
     conn = get conn, user_path(conn, :show, user)
     assert json_response(conn, 200)["data"] == %{"id" => user.id,
@@ -32,7 +37,7 @@ defmodule Mito.UserControllerTest do
     end
   end
 
-  test "creates resource when data is valid", %{conn: conn} do
+  test "creates user when data is valid", %{conn: conn} do
     user_params = params_for(:user, @valid_attrs)
     conn = post conn, user_path(conn, :create), user: user_params
 
@@ -47,7 +52,7 @@ defmodule Mito.UserControllerTest do
     assert Repo.get(User, user_id).password_hash
   end
 
-  test "renders resource when data is valid", %{conn: conn} do
+  test "renders user when data is valid", %{conn: conn} do
     user_params = params_for(:user, @valid_attrs)
     conn = post conn, user_path(conn, :create), user: user_params
     expected_params = Map.drop(user_params, [:name, :password, :password_hash])
@@ -55,13 +60,13 @@ defmodule Mito.UserControllerTest do
     assert Repo.get_by(User, expected_params)
   end
 
-  test "does not create resource and renders errors when data is invalid", %{conn: conn} do
+  test "does not create user and renders errors when data is invalid", %{conn: conn} do
     conn = post conn, user_path(conn, :create), user: @invalid_attrs
 
     assert json_response(conn, 422)["errors"] != %{}
   end
 
-  test "updates chosen resource when data is valid", %{conn: conn} do
+  test "updates chosen user when data is valid", %{conn: conn} do
     user = insert(:user)
     user_params = params_for(:user, @valid_attrs)
     conn = put conn, user_path(conn, :update, user), user: user_params
@@ -69,7 +74,7 @@ defmodule Mito.UserControllerTest do
     assert Repo.get_by(User, username: user_params.username)
   end
 
-  test "renders chosen resource when data is valid", %{conn: conn} do
+  test "renders chosen user when data is valid", %{conn: conn} do
     user = insert(:user)
     user_params = params_for(:user, @valid_attrs)
     conn = put conn, user_path(conn, :update, user), user: user_params
@@ -77,13 +82,13 @@ defmodule Mito.UserControllerTest do
   end
 
 
-  test "does not update chosen resource and renders errors when data is invalid", %{conn: conn} do
+  test "does not update chosen user and renders errors when data is invalid", %{conn: conn} do
     user = insert(:user)
     conn = put conn, user_path(conn, :update, user), user: @invalid_attrs
     assert json_response(conn, 422)["errors"] != %{}
   end
 
-  test "deletes chosen resource", %{conn: conn} do
+  test "deletes chosen user", %{conn: conn} do
     user = insert(:user)
     conn = delete conn, user_path(conn, :delete, user)
     assert response(conn, 204)

--- a/api/test/models/user_test.exs
+++ b/api/test/models/user_test.exs
@@ -8,7 +8,6 @@ defmodule Mito.UserTest do
   @invalid_attrs %{email: "", username: ""}
 
   setup do
-    IO.puts "Cleaning Ejabberd test user"
     case :ejabberd_auth.user_exists(@valid_attrs.username, "localhost") do
       true  -> :ejabberd_auth.remove_user(@valid_attrs.username, "localhost")
       _ -> :ok
@@ -41,5 +40,18 @@ defmodule Mito.UserTest do
     attrs = Map.merge(@valid_attrs, %{password: "123123123"})
     changeset = User.registration_changeset(%User{}, attrs)
     assert changeset.changes.name == "Name"
+  end
+
+  test "creation in ejabberd" do
+    user = insert(:user)
+    User.create_ejabberd_user(user, "localhost")
+    assert :ejabberd_auth.user_exists(user.username, "localhost")
+  end
+
+  test "deletion in ejabberd" do
+    user = insert(:user)
+    User.create_ejabberd_user(user, "localhost")
+    User.delete_ejabberd_user(user)
+    refute :ejabberd_auth.user_exists(user.username, "localhost")
   end
 end

--- a/api/web/controllers/api/user_controller.ex
+++ b/api/web/controllers/api/user_controller.ex
@@ -46,9 +46,13 @@ defmodule Mito.UserController do
   def delete(conn, %{"id" => id}) do
     user = Repo.get!(User, id)
 
-    # Here we use delete! (with a bang) because we expect
-    # it to always work (and if it does not, it will raise).
-    Repo.delete!(user)
+    case Repo.delete(user) do
+      {:ok, struct} -> User.delete_ejabberd_user(struct)
+      {:error, changeset} ->
+        conn
+        |> put_status(:unprocessable_entity)
+        |> render(Mito.ChangesetView, "error.json", changeset: changeset)
+    end
 
     send_resp(conn, :no_content, "")
   end

--- a/api/web/models/user.ex
+++ b/api/web/models/user.ex
@@ -46,10 +46,17 @@ defmodule Mito.User do
   end
 
   @doc """
-  Build changeset for registration
+  Register user on ejabberd server
   """
   def create_ejabberd_user(%User{username: username, password: password } = user, host) do
     :ejabberd_auth.try_register(username, host, password)
+  end
+
+  @doc """
+  Delete user from ejabberd server
+  """
+  def delete_ejabberd_user(%User{username: username}) do
+    :ejabberd_auth.remove_user(username, @host)
   end
 
   @doc """


### PR DESCRIPTION
# Enable users to be deleted

This PR adds the feature of a user to be deleted.

Whenever a API call is made to: `DELETE /api/users/:id`, the user is
deleted from both the backend db and from the ejabberd server.

- Add tests
- Refactor User Controller tests