### PR TITLE
[Backend] User token refresh

### DIFF
--- a/api/web/controllers/session_controller.ex
+++ b/api/web/controllers/session_controller.ex
@@ -10,4 +10,24 @@ defmodule Mito.SessionController do
       {:error, msg} -> render(conn, Mito.ChangesetView, "error.json", changeset: msg)
     end
   end
+
+  def refresh(conn, _params) do
+    {:ok, user} =
+      Auth.Guardian.Plug.current_claims(conn)
+      |> Auth.Guardian.resource_from_claims()
+
+    token = Auth.Guardian.Plug.current_token(conn)
+
+    case Auth.Guardian.refresh(token) do
+      {:ok, _old_stuff, {new_token, new_claims}} ->
+        conn
+        |> put_status(:ok)
+        |> render(Mito.UserView, "login.json", user: user, token: new_token)
+
+      {:error, _reason} ->
+        conn
+        |> put_status(:unauthorized)
+        |> render(Mito.ErrorView, "forbidden.json", error: "Not authenticated")
+    end
+  end
 end

--- a/api/web/router.ex
+++ b/api/web/router.ex
@@ -38,5 +38,6 @@ defmodule Mito.Router do
 
 
     resources "/users", UserController, except: [:create]
+    post "/sessions/refresh", SessionController, :refresh
   end
 end

--- a/api/web/views/error_view.ex
+++ b/api/web/views/error_view.ex
@@ -9,6 +9,10 @@ defmodule Mito.ErrorView do
     "Internal server error"
   end
 
+  def render("forbidden.json", error) do
+    %{error: error}
+  end
+
   # In case no render clause matches or no
   # template is found, let's render it as 500
   def template_not_found(_template, assigns) do


### PR DESCRIPTION
# User token refresh

This commit adds an endpoint on the backend for the user to be able to refresh his
access token

`POST api/sessions/refresh`