### PR TITLE
Add a validation endpoint for user

### DIFF
--- a/api/test/controllers/user_controller_test.exs
+++ b/api/test/controllers/user_controller_test.exs
@@ -43,4 +43,19 @@ defmodule Mito.UserControllerTest do
 
     assert json_response(conn, 422)["errors"] != %{}
   end
+
+  test "username doesnt exist", %{conn: conn} do
+    user_params = %{username: "new-user"}
+    conn = post conn, user_path(conn, :validate), user: user_params
+
+    assert json_response(conn, 200)["data"] == "Username available"
+  end
+
+  test "username exists", %{conn: conn} do
+    user = insert(:user, @valid_attrs)
+    user_params = %{username: user.username}
+    conn = post conn, user_path(conn, :validate), user: user_params
+
+    assert json_response(conn, 403)["data"] == "Username already exists"
+  end
 end

--- a/api/test/models/user_test.exs
+++ b/api/test/models/user_test.exs
@@ -49,4 +49,16 @@ defmodule Mito.UserTest do
     User.delete_ejabberd_user(user)
     refute :ejabberd_auth.user_exists(user.username, "localhost")
   end
+
+  test "unique_fields_changeset passing username" do
+    user_params = params_for(:user, username: "victorpre")
+    insert(:user, user_params)
+    refute User.unique_fields_changeset(%User{}, user_params).valid?
+  end
+
+  test "unique_fields_changeset passing email" do
+    user_params = params_for(:user, email: "victorpre@victorpre.com")
+    insert(:user, user_params)
+    refute User.unique_fields_changeset(%User{}, user_params).valid?
+  end
 end

--- a/api/web/controllers/api/user_controller.ex
+++ b/api/web/controllers/api/user_controller.ex
@@ -38,11 +38,12 @@ defmodule Mito.UserController do
     case changeset.valid? do
       true ->
         conn
-        |> send_resp(:ok, "")
+        |> put_status(:ok)
+        |> render(Mito.ChangesetView, "available.json", changeset: changeset)
       _ ->
         conn
         |> put_status(403)
-        |> render(Mito.ChangesetView, "error.json", changeset: changeset)
+        |> render(Mito.ChangesetView, "not_available.json", changeset: changeset)
     end
   end
 

--- a/api/web/controllers/api/user_controller.ex
+++ b/api/web/controllers/api/user_controller.ex
@@ -33,6 +33,19 @@ defmodule Mito.UserController do
     end
   end
 
+  def validate(conn, %{"user" => user_params}) do
+    changeset = User.unique_fields_changeset(%User{}, user_params)
+    case changeset.valid? do
+      true ->
+        conn
+        |> send_resp(:ok, "")
+      _ ->
+        conn
+        |> put_status(403)
+        |> render(Mito.ChangesetView, "error.json", changeset: changeset)
+    end
+  end
+
   def show(conn, %{"id" => id}) do
     user = Repo.get!(User, id)
     render(conn, "show.json", user: user)

--- a/api/web/models/user.ex
+++ b/api/web/models/user.ex
@@ -23,14 +23,14 @@ defmodule Mito.User do
   end
 
   def unique?(%{changes: %{username: username}} = changeset) do
-    case Mito.Repo.get_by(User, changes) do
+    case Mito.Repo.get_by(User, username: username) do
       nil -> changeset
       user -> add_error(changeset, :username, "already exists")
     end
   end
 
   def unique?(%{changes: %{email: email}} = changeset) do
-    case Mito.Repo.get_by(User, changes) do
+    case Mito.Repo.get_by(User, email: email) do
       nil -> changeset
       user -> add_error(changeset, :email, "already exists")
     end

--- a/api/web/models/user.ex
+++ b/api/web/models/user.ex
@@ -16,10 +16,24 @@ defmodule Mito.User do
     timestamps()
   end
 
-   def unique_fields_changeset(struct, params \\ %{}) do
+  def unique_fields_changeset(struct, params \\ %{}) do
     struct
     |> cast(params, @unique_fields, [])
-    |> validate_unique_fields
+    |> unique?
+  end
+
+  def unique?(%{changes: %{username: username}} = changeset) do
+    case Mito.Repo.get_by(User, changes) do
+      nil -> changeset
+      user -> add_error(changeset, :username, "already exists")
+    end
+  end
+
+  def unique?(%{changes: %{email: email}} = changeset) do
+    case Mito.Repo.get_by(User, changes) do
+      nil -> changeset
+      user -> add_error(changeset, :email, "already exists")
+    end
   end
 
   @doc """

--- a/api/web/router.ex
+++ b/api/web/router.ex
@@ -29,6 +29,7 @@ defmodule Mito.Router do
 
     resources "/users", UserController, only: [:create]
     post "/register", UserController, :create
+    post "/validate-user", UserController, :validate
     post "/login", SessionController, :login
   end
 

--- a/api/web/views/changeset_view.ex
+++ b/api/web/views/changeset_view.ex
@@ -16,4 +16,39 @@ defmodule Mito.ChangesetView do
     # as a JSON object. So we just pass it forward.
     %{errors: translate_errors(changeset)}
   end
+
+  def available_message(changeset) do
+    fields =
+      changeset.changes
+      |> Map.keys()
+      |> Enum.join(", ")
+
+    (fields <> " available")
+    |> String.capitalize()
+  end
+
+  def not_available_message(changeset) do
+    changeset.errors
+    |> Enum.map(fn {field, er} -> "#{field}" <> " #{render_detail(er)}" end)
+    |> Enum.join(", ")
+    |> String.capitalize()
+  end
+
+  def render("available.json", %{changeset: changeset}) do
+    %{status: "ok", data: available_message(changeset)}
+  end
+
+  def render("not_available.json", %{changeset: changeset}) do
+    %{status: "error", data: not_available_message(changeset)}
+  end
+
+  def render_detail({message, values}) do
+    Enum.reduce(values, message, fn {k, v}, acc ->
+      String.replace(acc, "%{#{k}}", to_string(v))
+    end)
+  end
+
+  def render_detail(message) do
+    message
+  end
 end


### PR DESCRIPTION
# Add a validation endpoint for user

`curl -X POST  http://localhost:4000/api/validate-user/ -d '{"user": {"email": "victor.presumido@gmail.com"}}'  -H "Content-Type: application/json"`

`POST /api/validate-user {"user": {"username": "", "email": ""} }`

***

## Success response:
`{"status":"ok","data":"email available"}`

## Error response: 
`{"status":"error","data":"Email already exists"}`